### PR TITLE
Update sources/gorilla.tcl

### DIFF
--- a/sources/gorilla.tcl
+++ b/sources/gorilla.tcl
@@ -1630,6 +1630,7 @@ proc gorilla::Open {{defaultFile ""}} {
 		-text $nativeName \
 		-values [list Root]
 
+	FocusRootNode
 	AddAllRecordsToTree
 	UpdateMenu
 	return "Open"
@@ -4668,7 +4669,10 @@ proc gorilla::AddGroupToTree {groupName} {
 	return $parentNode
 }
 
-
+proc gorilla::FocusRootNode {} {
+	focus .tree
+	.tree focus "RootNode"
+}
 #
 # Update Menu items
 #


### PR DESCRIPTION
Small patch that focuses the keyboard on the tree for keyboard navigation without having to click with the mouse.
