### PR TITLE
Fix for broken window matching in Unity a.k.a. generic icon. #161

### DIFF
--- a/utilities/make-deb.data/password-gorilla.desktop
+++ b/utilities/make-deb.data/password-gorilla.desktop
@@ -9,3 +9,4 @@ Icon=password-gorilla
 StartupNotify=false
 Terminal=false
 Categories=Utility
+StartupWMClass=Gorilla


### PR DESCRIPTION
See issue: [Ubuntu 16.04 Linux - icon in Unity doesn't match #161](https://github.com/zdia/gorilla/issues/161)