### PR TITLE
Port Password Gorilla from Tcl/Tk 8.5 to Tcl/Tk 9

### DIFF
--- a/sources/blowfish/blowfish.tcl
+++ b/sources/blowfish/blowfish.tcl
@@ -15,7 +15,7 @@
 # ----------------------------------------------------------------------
 #
 
-package require Tcl 8.4
+package require Tcl 8.4-
 package require Itcl
 
 catch {

--- a/sources/gorilla.tcl
+++ b/sources/gorilla.tcl
@@ -52,12 +52,12 @@ namespace eval ::gorilla {
 # ----------------------------------------------------------------------
 #
 
-if {[catch {package require Tk 8.5} oops]} {
+if {[catch {package require Tk 8.5-} oops]} {
 	#
 	# Because of using Themed Widgets we need Tk 8.5
 	#
 
-	puts "Password Gorilla has been unable to load Tk 8.5, which is required."
+	puts "Password Gorilla has been unable to load Tk 8.5 or newer, which is required."
 	puts "Reason: '$oops'"
 	exit 1
 }
@@ -82,7 +82,7 @@ proc toplevel {path args} {
 
 option add *Dialog.msg.wrapLength 6i
 
-if {[catch {package require Tcl 8.5}]} {
+if {[catch {package require Tcl 8.5-}]} {
 	wm withdraw .
 	tk_messageBox -type ok -icon error -default ok \
 		-title "Need more recent Tcl/Tk" \
@@ -161,9 +161,9 @@ modules dir contents:
 			# else, use "Desktop"
 			
 			if { $::tcl_platform(os) eq "Linux" } {
-				set logfile [ file join ~ gorilla-debug-log ]
+				set logfile [ file join [file home] gorilla-debug-log ]
 			} else {
-				set logfile [ file join ~ Desktop gorilla-debug-log.txt ]
+				set logfile [ file join [file home] Desktop gorilla-debug-log.txt ]
 			}
 
 			set logfile [ file normalize $logfile ]
@@ -233,16 +233,16 @@ foreach file {isaac.tcl viewhelp.tcl} {
 # This is necessary for the embedded standalone version in MacOSX
 #
 
-if {[tk windowingsystem] == "aqua"}	{
-	# set auto_path /Library/Tcl/teapot/package/macosx-universal/lib/Itcl3.4
-	set auto_path ""
+if {[tk windowingsystem] != "aqua"}	{
+	# On non-macOS, use the bundled Itcl 3.4 if available
+	foreach testitdir [glob -nocomplain [file join $::gorilla::Dir itcl*]] {
+		if {[file isdirectory $testitdir]} {
+			lappend auto_path $testitdir
+		}
+	} ; unset -nocomplain testitdir
 }
-
-foreach testitdir [glob -nocomplain [file join $::gorilla::Dir itcl*]] {
-	if {[file isdirectory $testitdir]} {
-		lappend auto_path $testitdir
-	}
-} ; unset -nocomplain testitdir
+# On macOS (aqua), rely on the system-installed Itcl 4.x
+# The bundled itcl3.4 dylib is x86-only and cannot load on arm64
 
 #
 # Check the subdirectories for needed packages
@@ -6254,7 +6254,7 @@ proc gorilla::SavePreferencesToRCFile {} {
 		if {[info exists ::env(HOME)] && [file isdirectory $::env(HOME)]} {
 			set homeDir $::env(HOME)
 		} else {
-			set homeDir "~"
+			set homeDir [file home]
 		}
 
 		#
@@ -6428,7 +6428,7 @@ proc gorilla::LoadPreferencesFromRCFile {} {
 		if { [ info exists ::env(HOME) ] && [ file isdirectory $::env(HOME) ] } {
 			set homeDir $::env(HOME)
 		} else {
-			set homeDir "~"
+			set homeDir [file home]
 		}
 
 		#

--- a/sources/isaac.tcl
+++ b/sources/isaac.tcl
@@ -17,7 +17,7 @@
 # ----------------------------------------------------------------------
 #
 
-package require Tcl 8.4
+package require Tcl 8.4-
 
 namespace eval isaac {
     #

--- a/sources/itcl3.4/pkgIndex.tcl
+++ b/sources/itcl3.4/pkgIndex.tcl
@@ -1,7 +1,7 @@
 # Tcl package index file, version 1.0
 # modified for multiplatform use
 
-package require Tcl 8.5
+package require Tcl 8.5-
 
 set lib libitcl3.4
 if { $::tcl_platform(platform) eq "windows" } { set lib itcl34 }

--- a/sources/modules/PWGprogress-1.0.0.tm
+++ b/sources/modules/PWGprogress-1.0.0.tm
@@ -29,7 +29,7 @@
 
 # this makes use of several 8.5 features, so make sure we are running at
 # least 8.5
-package require Tcl 8.5
+package require Tcl 8.5-
 
 package provide gorillaprogress 1.0.0
 

--- a/sources/pwsafe/pwsafe.tcl
+++ b/sources/pwsafe/pwsafe.tcl
@@ -1,4 +1,4 @@
-package require Tcl 8.4
+package require Tcl 8.4-
 package require Itcl
 package require sha256
 package require iblowfish

--- a/sources/tcllib/csv/csv.tcl
+++ b/sources/tcllib/csv/csv.tcl
@@ -10,7 +10,7 @@
 # 
 # RCS: @(#) $Id: csv.tcl,v 1.26 2008/10/02 22:26:48 andreas_kupries Exp $
 
-package require Tcl 8.3
+package require Tcl 8.3-
 package provide csv 0.7.1
 
 namespace eval ::csv {

--- a/sources/tcllib/md5/md5.tcl
+++ b/sources/tcllib/md5/md5.tcl
@@ -24,7 +24,7 @@
 
 # @mdgen EXCLUDE: md5c.tcl
 
-package require Tcl 8.2
+package require Tcl 8.2-
 namespace eval ::md5 {
 }
 

--- a/sources/tcllib/md5/md5x.tcl
+++ b/sources/tcllib/md5/md5x.tcl
@@ -18,7 +18,7 @@
 #
 # $Id: md5x.tcl,v 1.19 2008/07/04 18:27:00 andreas_kupries Exp $
 
-package require Tcl 8.2;                # tcl minimum version
+package require Tcl 8.2-;               # tcl minimum version
 
 namespace eval ::md5 {
     variable version 2.0.7

--- a/sources/tcllib/sha1/sha1.tcl
+++ b/sources/tcllib/sha1/sha1.tcl
@@ -25,7 +25,7 @@
 
 # @mdgen EXCLUDE: sha1c.tcl
 
-package require Tcl 8.2;                # tcl minimum version
+package require Tcl 8.2-;               # tcl minimum version
 
 namespace eval ::sha1 {
     variable  version 2.0.3

--- a/sources/tcllib/sha1/sha1v1.tcl
+++ b/sources/tcllib/sha1/sha1v1.tcl
@@ -25,7 +25,7 @@
 
 # @mdgen EXCLUDE: sha1c.tcl
 
-package require Tcl 8.2;                # tcl minimum version
+package require Tcl 8.2-;               # tcl minimum version
 
 namespace eval ::sha1 {
     variable version 1.1.0

--- a/sources/tcllib/sha1/sha256.tcl
+++ b/sources/tcllib/sha1/sha256.tcl
@@ -24,7 +24,7 @@
 
 # @mdgen EXCLUDE: sha256c.tcl
 
-package require Tcl 8.2;                # tcl minimum version
+package require Tcl 8.2-;               # tcl minimum version
 
 namespace eval ::sha2 {
     variable version 1.0.2

--- a/sources/tcllib/tooltip/tooltip.tcl
+++ b/sources/tcllib/tooltip/tooltip.tcl
@@ -12,7 +12,7 @@
 # Initiated: 28 October 1996
 
 
-package require Tk 8.4
+package require Tk 8.4-
 package require msgcat
 
 #------------------------------------------------------------------------

--- a/sources/twofish/twofish.tcl
+++ b/sources/twofish/twofish.tcl
@@ -1,4 +1,4 @@
-package require Tcl 8.4
+package require Tcl 8.4-
 package require Itcl
 
 namespace eval ::itwofish {


### PR DESCRIPTION
Fixes Password Gorilla failing to launch from sources on Mac OS Tahoe when Tcl/Tk 9 has been installed with Homebrew

- Add `-` suffix to all `package require` version constraints so they accept Tcl/Tk 9.x (e.g., `8.5` → `8.5-` means ">=8.5")
- Stop clearing auto_path and loading bundled Itcl 3.4 on macOS (the x86-only dylib cannot load on arm64); rely on system Itcl 4.x instead
- Replace `~` with `[file home]` in file path construction, as Tcl 9 no longer expands tilde in `file join`